### PR TITLE
update launch4j version and add path to jre options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
 				<plugin>
 					<groupId>com.akathist.maven.plugins.launch4j</groupId>
 					<artifactId>launch4j-maven-plugin</artifactId>
-					<version>1.7.25</version>
+					<version>2.1.1</version>
 					<executions>
 						<execution>
 							<id>l4j-gui</id>
@@ -462,6 +462,7 @@
 						</classPath>
 						<icon>${application.iconWin}</icon>
 						<jre>
+							<path>%PATH%</path>
 							<minVersion>${application.minJavaVersion}.0</minVersion>
 							<initialHeapSize>128</initialHeapSize>
 							<maxHeapSize>${application.maxHeapMB}</maxHeapSize>


### PR DESCRIPTION
The Launch4J plugin needed to be updated.  And in order to accommodate Java11 openjdks we need to add the path to the jre option: ([see here](https://sourceforge.net/p/launch4j/bugs/197/)) for similar Launch4J issue. 